### PR TITLE
Split out kvm code into its own recipe

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -53,6 +53,12 @@ suites:
       ganeti:
         master-node: true
         drbd: true
+  - name: kvm
+    run_list:
+      - recipe[ganeti]
+    attributes:
+      ganeti:
+        hypervisor: kvm
   - name: instance_image
     run_list:
       - recipe[ganeti::instance_image]

--- a/recipes/_kvm.rb
+++ b/recipes/_kvm.rb
@@ -1,0 +1,23 @@
+#
+# Cookbook:: ganeti
+# Recipe:: _kvm
+#
+# Copyright:: 2017, Oregon State University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+include_recipe 'kernel-modules'
+
+node['ganeti']['packages']['kvm'].each { |p| package p }
+
+# TODO: Fix upstream to support Ubuntu/Debian platforms
+kernel_module 'kvm' if node['platform_family'] == 'rhel' # ~FC023

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -34,11 +34,8 @@ apt_repository 'ganeti' do
 end
 
 include_recipe 'lvm'
+include_recipe "ganeti::_#{node['ganeti']['hypervisor']}"
 include_recipe 'ganeti::_drbd' if node['ganeti']['drbd']
-
-packages = node['ganeti']['packages'][node['ganeti']['hypervisor']]
-
-packages.each { |p| package p }
 
 package node['ganeti']['package_name'] do
   version node['ganeti']['version'] if node['ganeti']['version']

--- a/spec/unit/recipes/_kvm_spec.rb
+++ b/spec/unit/recipes/_kvm_spec.rb
@@ -1,0 +1,32 @@
+require_relative '../../spec_helper'
+
+describe 'ganeti::_kvm' do
+  ALL_PLATFORMS.each do |p|
+    context "#{p[:platform]} #{p[:version]}" do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(p).converge(described_recipe)
+      end
+      it 'converges successfully' do
+        expect { chef_run }.to_not raise_error
+      end
+      case p
+      when CENTOS_6, CENTOS_7
+        %w(qemu-kvm qemu-kvm-tools).each do |pkg|
+          it do
+            expect(chef_run).to install_package(pkg)
+          end
+        end
+        it do
+          expect(chef_run).to load_kernel_module('kvm')
+        end
+      when UBUNTU_12_04, UBUNTU_14_04
+        it do
+          expect(chef_run).to install_package('qemu-kvm')
+        end
+        it do
+          expect(chef_run).to_not load_kernel_module('kvm')
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -87,20 +87,6 @@ describe 'ganeti::default' do
               gpgkey: nil
             )
         end
-        case p
-        when CENTOS_6
-          %w(qemu-kvm qemu-kvm-tools).each do |pkg|
-            it do
-              expect(chef_run).to install_package(pkg)
-            end
-          end
-        when CENTOS_7
-          %w(qemu-kvm qemu-kvm-tools).each do |pkg|
-            it do
-              expect(chef_run).to install_package(pkg)
-            end
-          end
-        end
       when UBUNTU_12_04, UBUNTU_14_04
         it do
           expect(chef_run).to include_recipe('apt')
@@ -114,9 +100,6 @@ describe 'ganeti::default' do
               keyserver: 'keyserver.ubuntu.com',
               key: '38520275'
             )
-        end
-        it do
-          expect(chef_run).to install_package('qemu-kvm')
         end
         it do
           expect(chef_run).to install_package('ganeti2').with(version: nil)

--- a/test/integration/default/serverspec/server_spec.rb
+++ b/test/integration/default/serverspec/server_spec.rb
@@ -9,22 +9,17 @@ when 'redhat', 'centos'
     packages = %w(
       ganeti
       lvm2
-      qemu-kvm
-      qemu-kvm-tools
     )
   when 7
     packages = %w(
       ganeti
       lvm2
-      qemu-kvm
-      qemu-kvm-tools
     )
   end
 when 'debian', 'ubuntu'
   packages = %w(
     ganeti2
     lvm2
-    qemu-kvm
   )
 end
 
@@ -43,15 +38,6 @@ describe file('/etc/cron.d/ganeti') do
   its(:content) do
     should match(%r{45 1 \* \* \* root \[ -x /usr/sbin/ganeti-cleaner \] && \
 /usr/sbin/ganeti-cleaner master})
-  end
-end
-
-# Currently the drbd module is not included with the kernel installed on the
-# Ubuntu/Debian bento boxes, so lets skip those tests for now.
-case os[:family].downcase
-when 'redhat', 'centos'
-  describe kernel_module('kvm') do
-    it { should be_loaded }
   end
 end
 

--- a/test/integration/kvm/serverspec/kvm_spec.rb
+++ b/test/integration/kvm/serverspec/kvm_spec.rb
@@ -1,0 +1,29 @@
+require 'serverspec'
+
+set :backend, :exec
+
+case os[:family].downcase
+when 'redhat', 'centos'
+  packages = %w(
+    qemu-kvm
+    qemu-kvm-tools
+  )
+when 'debian', 'ubuntu'
+  packages = %w(
+    qemu-kvm
+  )
+end
+
+packages.each do |p|
+  describe package(p) do
+    it { should be_installed }
+  end
+end
+
+# Currently this only works on RHEL systems for now
+case os[:family].downcase
+when 'redhat', 'centos'
+  describe kernel_module('kvm') do
+    it { should be_loaded }
+  end
+end

--- a/test/smoke/default/_kvm.rb
+++ b/test/smoke/default/_kvm.rb
@@ -1,0 +1,6 @@
+# # encoding: utf-8
+
+# Inspec test for recipe ganeti::_kvm
+
+# The Inspec reference, with examples and extensive documentation, can be
+# found at http://inspec.io/docs/reference/resources/


### PR DESCRIPTION
This moves the hypervisor (currently kvm) resources into it's own recipe. It
also uses the kernel_module resource to load the lvm kernel module.