### PR TITLE
Don't set default settings for instance-image

### DIFF
--- a/attributes/instance_image.rb
+++ b/attributes/instance_image.rb
@@ -12,24 +12,4 @@ default['ganeti']['instance_image']['apt'] = {
   'components' => %w(main),
   'key' => 'http://ftp.osuosl.org/pub/osl/ganeti-instance-image/apt/repo.gpg'
 }
-default['ganeti']['instance_image']['config_defaults'] = {
-  'arch' => 'x86_64',
-  'boot_size' => '',
-  'cache_dir' => '/var/lib/cache/ganeti-instance-image',
-  'cdinstall' => 'no',
-  'customize_dir' => '',
-  'export_dir' => '',
-  'filesystem' => 'ext4',
-  'image_cleanup' => 'no',
-  'image_debug' => '0',
-  'image_dir' => '',
-  'image_name' => '',
-  'image_type' => 'dump',
-  'image_url' => '',
-  'image_verify' => 'yes',
-  'kernel_args' => '',
-  'nomount' => '',
-  'overlay' => '',
-  'swap_size' => '',
-  'swap' => 'yes'
-}
+default['ganeti']['instance_image']['config_defaults'] = {}

--- a/spec/unit/recipes/instance_image_spec.rb
+++ b/spec/unit/recipes/instance_image_spec.rb
@@ -7,6 +7,7 @@ describe 'ganeti::instance_image' do
       cached(:chef_run) do
         ChefSpec::SoloRunner.new(p) do |node|
           lsb_codename = node['lsb']['codename']
+          node.set['ganeti']['instance_image']['config_defaults'] = { arch: 'x86_64' }
         end.converge(described_recipe)
       end
       include_context 'common_stubs'
@@ -32,25 +33,7 @@ describe 'ganeti::instance_image' do
             source: 'defaults.sh.erb',
             variables: {
               params: {
-                'arch' => 'x86_64',
-                'boot_size' => '',
-                'cache_dir' => '/var/lib/cache/ganeti-instance-image',
-                'cdinstall' => 'no',
-                'customize_dir' => '',
-                'export_dir' => '',
-                'filesystem' => 'ext4',
-                'image_cleanup' => 'no',
-                'image_debug' => '0',
-                'image_dir' => '',
-                'image_name' => '',
-                'image_type' => 'dump',
-                'image_url' => '',
-                'image_verify' => 'yes',
-                'kernel_args' => '',
-                'nomount' => '',
-                'overlay' => '',
-                'swap_size' => '',
-                'swap' => 'yes'
+                'arch' => 'x86_64'
               }
             }
           )
@@ -65,25 +48,7 @@ describe 'ganeti::instance_image' do
           )
       end
       [
-        /^ARCH="x86_64"$/,
-        /^BOOT_SIZE=""$/,
-        %r{^CACHE_DIR="/var/lib/cache/ganeti-instance-image"$},
-        /^CDINSTALL="no"$/,
-        /^CUSTOMIZE_DIR=""$/,
-        /^EXPORT_DIR=""$/,
-        /^FILESYSTEM="ext4"$/,
-        /^IMAGE_CLEANUP="no"$/,
-        /^IMAGE_DEBUG="0"$/,
-        /^IMAGE_DIR=""$/,
-        /^IMAGE_NAME=""$/,
-        /^IMAGE_TYPE="dump"$/,
-        /^IMAGE_URL=""$/,
-        /^IMAGE_VERIFY="yes"$/,
-        /^KERNEL_ARGS=""$/,
-        /^NOMOUNT=""$/,
-        /^OVERLAY=""$/,
-        /^SWAP_SIZE=""$/,
-        /^SWAP="yes"$/
+        /^ARCH="x86_64"$/
       ].each do |line|
         it do
           expect(chef_run).to render_file('/etc/default/ganeti-instance-image').with_content(line)


### PR DESCRIPTION
Let's not override any upstream settings and let the user of this cookbook
decide what those defaults should be compared to what upstream uses. This also
fixes a problem where the cache_dir was set incorrectly.