### PR TITLE
Work around issue with --enabled-disk-templates on older versions of Ganeti

### DIFF
--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -45,6 +45,38 @@ describe 'ganeti::default' do
             )
         end
       end
+      context 'master on < ganeti-2.9.0' do
+        cached(:chef_run) do
+          ChefSpec::SoloRunner.new(p) do |node|
+            node.set['ganeti']['master-node'] = true
+            node.set['ganeti']['version'] = '2.6.0'
+          end.converge(described_recipe)
+        end
+        it do
+          expect(chef_run).to run_execute('ganeti-initialize')
+            .with(
+              command: '/usr/sbin/gnt-cluster init  --master-netdev=br0 ' \
+                       '--enabled-hypervisors=kvm -N mode=bridged,link=br0  ',
+              creates: '/var/lib/ganeti/config.data'
+            )
+        end
+      end
+      context 'master on >= ganeti-2.9.0' do
+        cached(:chef_run) do
+          ChefSpec::SoloRunner.new(p) do |node|
+            node.set['ganeti']['master-node'] = true
+            node.set['ganeti']['version'] = '2.15.0'
+          end.converge(described_recipe)
+        end
+        it do
+          expect(chef_run).to run_execute('ganeti-initialize')
+            .with(
+              command: '/usr/sbin/gnt-cluster init --enabled-disk-templates=plain,drbd --master-netdev=br0 ' \
+                       '--enabled-hypervisors=kvm -N mode=bridged,link=br0  ',
+              creates: '/var/lib/ganeti/config.data'
+            )
+        end
+      end
       it do
         expect(chef_run).to enable_service('ganeti').with(supports: { status: true, restart: true })
       end


### PR DESCRIPTION
--enabled-disk-templates was added in Ganeti 2.9.0 so let's add logic to deal
with that not being available to older.